### PR TITLE
Change table name to person from persons in migration 

### DIFF
--- a/src/main/resources/changelogs/addOtherJobPosition.xml
+++ b/src/main/resources/changelogs/addOtherJobPosition.xml
@@ -7,7 +7,7 @@
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <changeSet id="US37_addOtherJobPosition" author="marcint">
-        <addColumn tableName="persons">
+        <addColumn tableName="person">
             <column name="is_other" type="boolean" defaultValueBoolean="false" />
         </addColumn>
     </changeSet>


### PR DESCRIPTION
addOtherJobPosition. There has been another pull request which replaced old persons table with new person and after this, it caused errors for migrations.
